### PR TITLE
Allow to pass chrome flags to a browser capability

### DIFF
--- a/bin/elementexplorer.js
+++ b/bin/elementexplorer.js
@@ -190,13 +190,17 @@ var startRepl = function() {
 var startUp = function() {
   // Resolve the path for the chrome extension.
   var extensionPath = path.resolve(__dirname, '../extension');
-
+  var arrChromeOptions = ['--load-extension=' + extensionPath];
+  arrChromeOptions = arrChromeOptions.concat(process.argv.filter(function(arg) {
+    return arg.indexOf('--') === 0;
+  }));
+  
   driver = new webdriver.Builder().
       usingServer('http://localhost:4444/wd/hub').
       withCapabilities({
         'browserName': 'chrome',
         'chromeOptions': {
-          'args': ['--load-extension=' + extensionPath]
+          'args': arrChromeOptions
         }
       }).build();
 


### PR DESCRIPTION
I've a requirement to call cross-domain XHR request which is not possible without `--disable-web-security` flag. AFAIK, all chrome specific flags start with `--` but I could be wrong.

This fix allows me to pass various chrome flags to a browser capability. For example,

`elementor http://localhost/myapp/index.html --disable-web-security --allow-file-access-from-files`